### PR TITLE
Fix missing bounding boxes X/Y for gcv2hocr

### DIFF
--- a/gcv2hocr.py
+++ b/gcv2hocr.py
@@ -51,10 +51,10 @@ class GCVAnnotation:
         self.lang = lang
         self.ocr_class = ocr_class
         self.content = content
-        self.x0 = box[0]['x']
-        self.y0 = box[0]['y']
-        self.x1 = box[2]['x']
-        self.y1 = box[2]['y']
+        self.x0 = box[0]['x'] if 'x' in box[0] else 0
+        self.y0 = box[0]['y'] if 'y' in box[0] else 0
+        self.x1 = box[2]['x'] if 'x' in box[2] else 0
+        self.y1 = box[2]['y'] if 'y' in box[2] else 0
 
     def maximize_bbox(self):
         self.x0 = min([w.x0 for w in self.content])


### PR DESCRIPTION
If the bounding box X/Y is undefined then assume 0 (I believe google drops the key if value is zero for some reason).

Fixes #6

Found this stackoverflow question that answered it:
https://stackoverflow.com/questions/39378862/incomplete-coordinate-values-for-google-vision-ocr

Example of missing bounding box keys (that made the code fail for me on several PDF files):
```

        {
          "locale": "en",
          "description": "<text removed>",
          "boundingPoly": {
            "vertices": [
              {
                "x": 194
              },
              {
                "x": 1333
              },
              {
                "x": 1333,
                "y": 1835
              },
              {
                "x": 194,
                "y": 1835
              }
            ]
          }
        },
```
This is the first item in `textAnnotations` which means it is the full page text.