### PR TITLE
Fix negative bbox values (so they do not occur)

### DIFF
--- a/gcv2hocr.py
+++ b/gcv2hocr.py
@@ -51,10 +51,10 @@ class GCVAnnotation:
         self.lang = lang
         self.ocr_class = ocr_class
         self.content = content
-        self.x0 = box[0]['x'] if 'x' in box[0] else 0
-        self.y0 = box[0]['y'] if 'y' in box[0] else 0
-        self.x1 = box[2]['x'] if 'x' in box[2] else 0
-        self.y1 = box[2]['y'] if 'y' in box[2] else 0
+        self.x0 = box[0]['x'] if 'x' in box[0] and box[0]['x'] > 0 else 0
+        self.y0 = box[0]['y'] if 'y' in box[0] and box[0]['y'] > 0 else 0
+        self.x1 = box[2]['x'] if 'x' in box[2] and box[2]['x'] > 0 else 0
+        self.y1 = box[2]['y'] if 'y' in box[2] and box[2]['y'] > 0 else 0
 
     def maximize_bbox(self):
         self.x0 = min([w.x0 for w in self.content])


### PR DESCRIPTION
I had issues when trying to generate the ocr overlay using hocr-pdf tool from hocr-tools (https://github.com/tmbdev/hocr-tools) because `bbox` should be an unsigned integer but gcv2hocr.py generate bbox with negative numbers (if the JSON vision request has negative numbers). Using this fix generates the HOCR correctly by following spec (and the OCR invisible text shows up in the correct place so it does not break anything).

Here is the HOCR bbox spec for clarification:
http://kba.cloud/hocr-spec/1.2/#bbox

And here is an issue and PR I created for the hocr-tools before I realized this was an issue with this project instead:
https://github.com/tmbdev/hocr-tools/issues/127
https://github.com/tmbdev/hocr-tools/pull/128