### PR TITLE
use the --savefile argument of hocr-pdf

### DIFF
--- a/makepdf.sh
+++ b/makepdf.sh
@@ -25,7 +25,7 @@ do
 done
 
 echo "Generating out.pdf"
-python hocr-pdf ./ > out0.pdf
+python hocr-pdf --savefile out0.pdf ./
 
 echo "Reducing pdf size"
 gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/default -dNOPAUSE -dQUIET -dBATCH -dAutoRotatePages=/None -sOutputFile=out.pdf out0.pdf


### PR DESCRIPTION
By using the --savefile argument when calling the hocr-pdf you can avoid sending the resulting pdf to stdout which may cause codepage errors when you use a custom default codepage in your command-line environment.