### PR TITLE
Iterate through the buf to escape XML chars

### DIFF
--- a/main.c
+++ b/main.c
@@ -6,7 +6,6 @@
 #define MAX 8192
 
 char bufcopy(char buf0[MAX], char buf[MAX]);
-char *replace(char *str, const char *what, const char *with);
 
 int main(int argc, char *argv[ ]){
 	FILE *fpin,*fpout;
@@ -180,9 +179,27 @@ int main(int argc, char *argv[ ]){
 
 // Replace xml escape characters
 
-			while ((p = strstr(buf,"&")) != NULL) replace(buf,"&", "&amp;");				
-			while ((p = strstr(buf,"<")) != NULL) replace(buf,"<", "&lt;");
-			while ((p = strstr(buf,">")) != NULL) replace(buf,"<", "&gt;");
+	buf0[0] = '\0';
+	int iter_xml = 0, single_char, len_xml;
+	while ((single_char = buf[iter_xml++])) {
+		switch (single_char) {
+		case '<':
+			strcat(buf0, "&lt;");
+			break;
+		case '>':
+			strcat(buf0, "&gt;");
+			break;
+		case '&':
+			strcat(buf0, "&amp;");
+			break;
+		default:
+			len_xml = strlen(buf0);
+			buf0[len_xml] = single_char;
+			buf0[len_xml+1] = '\0';
+			break;
+		}
+	}	
+	bufcopy(buf, buf0);
 
 // Extract text and coodinates
 
@@ -313,17 +330,4 @@ char bufcopy(char buf0[MAX], char buf[MAX]){
 	for(i=0;i<MAX;++i){
 		buf0[i] = buf[i];
   	}
-}
-
-//This routine is written by URIN HACK (http://urin.github.io/posts/2018/replace-string-by-c-lang)
-char *replace(char *str, const char *what, const char *with)
-{
-  if (!*what) { return str; }
-  char *what_pos = strstr(str, what);
-  if (!what_pos) { return str; }
-  const size_t what_len = strlen(what), with_len = strlen(with);
-  const char *remain = what_pos + what_len;
-  memmove(what_pos + with_len, remain, strlen(remain) + 1);
-  memcpy(what_pos, with, with_len);
-  return str;
 }


### PR DESCRIPTION
The current XML escaping mechanism is faulty, it produces an infinite loop when encounters an '&', because it replaces '&' with "&amp;" which also contains an '&'