### PR TITLE
add quotes when parsing JSON parameters

### DIFF
--- a/main.c
+++ b/main.c
@@ -52,13 +52,13 @@ int main(int argc, char *argv[ ]){
 
 	while(fgets(buf, MAX, fpin) != NULL ){
 
-		if (strstr(buf, "locale") != NULL){
+		if (strstr(buf, "\"locale\":") != NULL){
 			fprintf(fpout,"%s",buf);
 			fprintf(fpout,"\n");
 			continue;
 		}
 	
-		if (strstr(buf, "boundingPoly") != NULL){
+		if (strstr(buf, "\"boundingPoly\":") != NULL){
 			break;
 		}
 	}
@@ -66,7 +66,7 @@ int main(int argc, char *argv[ ]){
 // Delete lines below "fullTextAnnotation" tag
 
 	while(fgets(buf, MAX, fpin) != NULL ){
-		if (strstr(buf,"fullTextAnnotation") != NULL){
+		if (strstr(buf,"\"fullTextAnnotation\":") != NULL){
 	 		break;
 		}
 


### PR DESCRIPTION
Currently the program fails to process OCR'd pages which contain the word "locale" in the OCR's text, because it interprets OCR'd text as locale definition! 

Searching for JSON parameter names in quotation signs with a colon should be safe, because in unescaped quotation signs followed by a colon are only used in JSON as parameter names.