### PR TITLE
enforce encoding="utf-8"

### DIFF
--- a/gcv2hocr.py
+++ b/gcv2hocr.py
@@ -163,14 +163,14 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
-    instream = sys.stdin if args.gcv_file is '-' else open(args.gcv_file, 'r')
+    instream = sys.stdin if args.gcv_file is '-' else open(args.gcv_file, 'r', encoding='utf-8' )
     resp = json.load(instream)
     resp = resp['responses'][0] if 'responses' in resp and len(resp['responses']) >= 0 and "textAnnotations" in resp['responses'][0] else False
     del(args.gcv_file)
     page = fromResponse(resp, **args.__dict__)
 
     if args.savefile:
-        with (open(args.savefile, 'w', encoding="utf-8") if str == bytes else open(args.savefile, 'w')) as outfile:
+        with (open(args.savefile, 'w', encoding="utf-8")) as outfile:
             outfile.write(page.render().encode('utf-8') if str == bytes else page.render())
             outfile.close()
     else:


### PR DESCRIPTION
Encoding="utf-8" should be enforced, otherwise the script fails in environments with a non-standard command line locale.

The UTF-8 encoding of the resulting file was already specified in the <meta http-equiv="Content-Type" content="text/html;charset=utf-8" /> tag. Hence, Python 3 should always output a utf-8 file.