### PR TITLE
content=[] when initializing GCVAnnotation

### DIFF
--- a/gcv2hocr.py
+++ b/gcv2hocr.py
@@ -88,6 +88,7 @@ def fromResponse(resp, baseline_tolerance=2, **kwargs):
         page = GCVAnnotation(
             ocr_class='ocr_page',
             htmlid='page_0',
+            content=[],
             box=box,
             **kwargs
         )
@@ -98,6 +99,7 @@ def fromResponse(resp, baseline_tolerance=2, **kwargs):
                 page = GCVAnnotation(
                     ocr_class='ocr_page',
                     htmlid='page_0',
+                    content=[],
                     box=box,
                     **kwargs
                     )


### PR DESCRIPTION
I cannot explain this behaviour, but without this addition I am getting non-empty objects when using the function in a multithreading environment (multiprocessing pool or concurrent.futures  ThreadPoolExecutor)